### PR TITLE
Engine::Scored: honor the rareness argument

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,12 @@ Revision history for Hailo
       are safe against existing brain files. See docs/api-integration.md
       for the full surface description and integration guidance.
 
+    - Engine::Scored: honor the inherited 'rareness' argument. Before
+      computing the pivot probability distribution, candidates whose
+      brain-wide count is below 'rareness' are dropped. If that
+      empties the candidate list, Scored falls back to selecting a
+      random expression (the existing no-input-match path).
+
 0.75 2018-11-28 12:08:58
 
     - In 0.73 we very aggressively put "use v5.28.0" without any

--- a/docs/api-integration.md
+++ b/docs/api-integration.md
@@ -139,9 +139,12 @@ hailo --brain PATH \
   exclusive with `interval`).
 
 **Trade-off:** ~10× CPU per reply. Quality improvement is real for
-well-trained brains. The Scored engine does *not* currently honor the
-`rareness` knob (it uses its own pivot probability distribution); if
-you want the `rareness` effect, stay on the `Default` engine.
+well-trained brains. The Scored engine honors the `rareness` knob too:
+it applies the minimum-count filter to the input-token pivot candidates
+before computing its own probability distribution over them. If the
+filter empties the candidate list, Scored falls back to selecting a
+random expression, matching the behavior you'd get from
+`--random-reply`.
 
 ---
 

--- a/lib/Hailo/Engine/Scored.pm
+++ b/lib/Hailo/Engine/Scored.pm
@@ -35,6 +35,14 @@ sub reply {
         } keys %$token_cache;
     }
 
+    # Apply the rareness floor inherited from Default: drop candidates
+    # whose brain-wide count is below it. If this empties the candidate
+    # list, _generate_reply falls back to a random expression.
+    if (@token_counts) {
+        my $min = $self->rareness;
+        @token_counts = grep { $_->[1] >= $min } @token_counts;
+    }
+
     my $token_probs = $self->_get_pivot_probabilites(\@token_counts);
     my @started = gettimeofday();
     my $iterations = 0;
@@ -260,6 +268,18 @@ best one.
 
 You can not specify both C<iterations> and C<interval> at the same time. If
 neither is specified, a default C<interval> of 0.5 seconds will be used.
+
+=head3 C<rareness>
+
+Inherited from L<Hailo::Engine::Default|Hailo::Engine::Default>. Acts as a
+minimum occurrence count filter over the input tokens before the pivot
+probability distribution is computed: candidates whose brain-wide count
+is below this threshold are dropped. If every candidate is filtered out,
+the engine falls back to selecting a random expression.
+
+=head3 C<repeat_limit>
+
+Inherited from L<Hailo::Engine::Default|Hailo::Engine::Default>.
 
 =head1 AUTHORS
 

--- a/t/hailo/engine_args.t
+++ b/t/hailo/engine_args.t
@@ -1,7 +1,7 @@
 use v5.10.0;
 use strict;
 use warnings;
-use Test::More tests => 7;
+use Test::More tests => 11;
 use Hailo;
 
 $SIG{__WARN__} = sub {
@@ -58,4 +58,47 @@ $SIG{__WARN__} = sub {
     $h->learn("hello there good sirs");
     my $reply = $h->reply("hello");
     ok( defined $reply && length $reply, "reply defined even with rareness=999" );
+}
+
+# The Scored engine inherits rareness from Default and honors it when
+# filtering input-token pivot candidates.
+{
+    my $h = Hailo->new(
+        engine_class => 'Scored',
+        engine_args  => { rareness => 1, iterations => 5 },
+    );
+    $h->learn("hello there good sirs");
+    is( $h->_engine->rareness, 1, "Scored engine honors rareness arg" );
+}
+
+{
+    my $h = Hailo->new(
+        engine_class => 'Scored',
+        engine_args  => { iterations => 5 },
+    );
+    $h->learn("hello there good sirs");
+    is( $h->_engine->rareness, 2, "Scored engine inherits rareness default" );
+}
+
+# Smoke test: Scored produces a reply with rareness=1 on a tiny brain.
+{
+    my $h = Hailo->new(
+        engine_class => 'Scored',
+        engine_args  => { rareness => 1, iterations => 5 },
+    );
+    $h->learn("hello there good sirs");
+    my $reply = $h->reply("hello");
+    ok( defined $reply && length $reply, "Scored reply defined with rareness=1" );
+}
+
+# Smoke test: Scored still returns something when rareness filters every
+# candidate (fallback to random expression via _generate_reply).
+{
+    my $h = Hailo->new(
+        engine_class => 'Scored',
+        engine_args  => { rareness => 999, iterations => 5 },
+    );
+    $h->learn("hello there good sirs");
+    my $reply = $h->reply("hello");
+    ok( defined $reply && length $reply, "Scored reply defined with rareness=999" );
 }


### PR DESCRIPTION
## Summary

- Scored inherits `rareness` from Default but previously ignored it. Apply `rareness` as a pre-filter in `reply()`: drop input-token candidates whose brain-wide count is below the threshold before handing the survivors to `_get_pivot_probabilites`.
- If every candidate is filtered out, Scored falls through to the existing no-input-match path in `_generate_reply` (random expression). No new crash surface.
- POD updated with `rareness` and `repeat_limit` under the Scored `engine_args` section.
- `docs/api-integration.md` updated to remove the previous "Scored does not honor rareness" caveat.
- `t/hailo/engine_args.t` extended with Scored assertions (arg inheritance, default, smoke-tests at rareness=1 and rareness=999).

## Why

Lets `--engine Scored --engine-args '{\"rareness\":1}'` behave analogously to the Default engine — low rareness amplifies the weight of rare input tokens, high rareness restricts to common ones. Without this, switching engines meant losing the creativity knob.

## Base

**Stacked on #1** (`feature/engine-default-rareness` → `master`). This PR's base is `feature/engine-default-rareness`, so it should be reviewed and merged after #1. Once #1 merges to master, GitHub will automatically retarget this PR to master.

## Test plan

- [x] 4 new assertions in `t/hailo/engine_args.t` (11 total, all passing)
- [x] Runnable pre-existing test subset still passes
- [x] Fallback path exercised: `rareness=999` with Scored returns a defined non-empty reply via random-expression path